### PR TITLE
Exercise 02 Task 02 Step 11 RG Name Change

### DIFF
--- a/Instructions/az-100-01__instructions.md
+++ b/Instructions/az-100-01__instructions.md
@@ -203,7 +203,7 @@ The main tasks for this exercise are as follows:
 
     - Subscription: the same subscription you selected in the previous exercise
 
-    - Resource group: **az1000102-RG**
+    - Resource group: **az1000101-RG**
 
     - Location: the name of the Azure region which you selected in the previous exercise
 


### PR DESCRIPTION
Exercise 02 Task 02 Step 11 Second bullet point.

In the first exercise the user is restricted from resource group `az1000102-RG`.

When you try to select it in Exercise 2 Task 2 Step 11 point 2 it is not an option because of RBAC.

This PR changes the resource group from `az1000102-RG` to `az1000101-RG` which fixes the lab steps.