### PR TITLE
Update az-100-02b__instructions.md

### DIFF
--- a/Instructions/az-100-02b__instructions.md
+++ b/Instructions/az-100-02b__instructions.md
@@ -139,7 +139,7 @@ The main tasks for this exercise are as follows:
 
     - Name: **az10002bshare1**
 
-    - Quota: none
+    - Quota: leave blank
 
 
 #### Task 2: Prepare Windows Server 2016 for use with Azure File Sync
@@ -181,7 +181,7 @@ The main tasks for this exercise are as follows:
 1. From the Windows PowerShell console, install the latest AzureRM module by running the following:
 
    ```
-   Install-Module -Name AzureRM
+   Install-Module -Name Az -AllowClobber
    ```
 
    > **Note**: When prompted, confirm that you want to proceed with the installation from PSGallery repository.
@@ -262,7 +262,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 2: Install the Azure File Sync Agent.
 
-1. Within the RDP session, start another instance of Internet Explorer, browse to Microsoft Download Center at [**https://go.microsoft.com/fwlink/?linkid=858257**](https://go.microsoft.com/fwlink/?linkid=858257) and download the Azure File Sync Agent Windows Installer file **StorageSyncAgent_V5_WS2016.msi**.
+1. Within the RDP session, start another instance of Internet Explorer, browse to Microsoft Download Center at [**https://go.microsoft.com/fwlink/?linkid=858257**](https://go.microsoft.com/fwlink/?linkid=858257) and download the Azure File Sync Agent Windows Installer file **StorageSyncAgent_WS2016.msi**.
 
 1. Once the download completes, run the Storage Sync Agent Setup wizard with the default settings to install Azure File Sync Agent.
 


### PR DESCRIPTION
Hello,
I had a problem complete subject lab. Issue occurs at Azure File Sync Server Registration post selecting subscription (Line 278) error message indicating Get-AzResourceGroup is not recognized cmd - as setup was trying to execute it. I have found out what was wrong - this command is part of module AZ but AzureRM was used in lab. Solution was to remove installed AzureRM and install AZ.

Please find below references helped me to understand issue.
PS. I'm during AZ Certs learning and I have found couple more mismatches / things makes me confused in instructions, so I will be more than happy to update instructions for further generations :)

https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-2.2.0
https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-2.2.0
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/storage/files/storage-sync-files-deployment-guide.md